### PR TITLE
Fixed dead links in Readme files

### DIFF
--- a/config/backends/README.md
+++ b/config/backends/README.md
@@ -74,7 +74,7 @@ Check the NVIDIA guides for instructions on setting up CUDA on the NVIDIA [websi
 ### Nd4jBackend$NoAvailableBackendException
 
 ```markup
- org.nd4j.linalg.factory.Nd4jBackend$NoAvailableBackendException: Please ensure that you have an nd4j backend on your classpath. Please see: https://deeplearning4j.konduit.ai/nd4j/backend
+ org.nd4j.linalg.factory.Nd4jBackend$NoAvailableBackendException: Please ensure that you have an nd4j backend on your classpath. Please see: https://deeplearning4j.konduit.ai/multi-project/explanation/configuration/backends#nd4jbackendusdnoavailablebackendexception
 	at org.nd4j.linalg.factory.Nd4jBackend.load(Nd4jBackend.java:221)
 	at org.nd4j.linalg.factory.Nd4j.initContext(Nd4j.java:5091)
 	... 2 more

--- a/getting-started/quickstart.md
+++ b/getting-started/quickstart.md
@@ -222,7 +222,7 @@ To use the template:
 
 Deeplearning4j is a framework that lets you pick and choose with everything available from the beginning. We're not Tensorflow \(a low-level numerical computing library with automatic differentiation\) or Pytorch. Deeplearning4j has several subprojects that make it easy-ish to build end-to-end applications.
 
-If you'd like to deploy models to production, you might like our [model import from Keras](https://deeplearning4j.konduit.ai/keras-import/overview).
+If you'd like to deploy models to production, you might like our [model import from Keras](https://deeplearning4j.konduit.ai/deeplearning4j/how-to-guides/keras-import).
 
 Deeplearning4j has several submodules. These range from a visualization UI to distributed training on Spark. For an overview of these modules, please look at the [**Deeplearning4j examples on Github**](https://github.com/eclipse/deeplearning4j-examples).
 

--- a/getting-started/quickstart/README.md
+++ b/getting-started/quickstart/README.md
@@ -222,7 +222,7 @@ To use the template:
 
 Deeplearning4j is a framework that lets you pick and choose with everything available from the beginning. We're not Tensorflow \(a low-level numerical computing library with automatic differentiation\) or Pytorch. Deeplearning4j has several subprojects that make it easy-ish to build end-to-end applications.
 
-If you'd like to deploy models to production, you might like our [model import from Keras](https://deeplearning4j.konduit.ai/keras-import/overview).
+If you'd like to deploy models to production, you might like our [model import from Keras](https://deeplearning4j.konduit.ai/deeplearning4j/how-to-guides/keras-import).
 
 Deeplearning4j has several submodules. These range from a visualization UI to distributed training on Spark. For an overview of these modules, please look at the [**Deeplearning4j examples on Github**](https://github.com/eclipse/deeplearning4j-examples).
 


### PR DESCRIPTION
Fixed dead links pointing to non-existing pages.

Old links -
*https://deeplearning4j.konduit.ai/keras-import/overview

*https://deeplearning4j.konduit.ai/nd4j/backend

New links -
*https://deeplearning4j.konduit.ai/deeplearning4j/how-to-guides/keras-import

*https://deeplearning4j.konduit.ai/multi-project/explanation/configuration/backends#nd4jbackendusdnoavailablebackendexception